### PR TITLE
ci: use this action to inspect its development process

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,44 @@
+name: listendev
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  development:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Self inspect ourselves
+      - uses: ./
+        with:
+          ci: true
+          jwt: ${{ secrets.LISTENDEV_TOKEN }}
+
+      - name: Setup Node.JS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run prettier
+        run: npm run format-check
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
Fixes #59 

This PR adds a GitHub action workflow to inspect the development process of this action itself.

This way we're going to have visibility (SCA and runtime threats) into the installation of the dependencies, into the build phase, and into the test phase.

- [x] I have read the [contributing guidelines](https://github.com/listendev/action/blob/main/.github/CONTRIBUTING.md)
- [x] I have written unit tests
- [x] I have made sure that the pull request is of reasonable size and can be easily reviewed
